### PR TITLE
fix: ensure we callback on .end

### DIFF
--- a/src/muxer.js
+++ b/src/muxer.js
@@ -56,9 +56,13 @@ class MultiplexMuxer extends EventEmitter {
   /**
    * Ends the connection and all of its streams
    * @param {function(Error)} callback
+   * @returns {void}
    */
   end (callback) {
     callback = callback || noop
+    if (this.multiplex.destroyed) {
+      return nextTick(callback)
+    }
     this.multiplex.once('close', callback)
     this.multiplex.close()
   }

--- a/test/muxer.spec.js
+++ b/test/muxer.spec.js
@@ -1,0 +1,29 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 5] */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(require('chai-checkmark'))
+chai.use(dirtyChai)
+
+const pair = require('pull-pair/duplex')
+const mplex = require('../src')
+
+describe('Mplex', () => {
+  it('multiple calls to end should call back', (done) => {
+    const p = pair()
+    const dialer = mplex.dialer(p[0])
+
+    expect(2).checks(done)
+
+    dialer.end((err) => {
+      expect(err).to.not.exist().mark()
+    })
+
+    dialer.end((err) => {
+      expect(err).to.not.exist().mark()
+    })
+  })
+})


### PR DESCRIPTION
If the muxer was already destroyed and `.end` was called, the callback would never be called since `'close'` would not be emitted. This change fixes that by checking the destroyed status of the multiplexer.