### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 pull-plex
 ===================
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/freenode-%23libp2p-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
+[![](https://img.shields.io/codecov/c/github/libp2p/pull-mplex.svg?style=flat-square)](https://codecov.io/gh/libp2p/pull-mplex)
+[![](https://img.shields.io/travis/libp2p/pull-mplex.svg?style=flat-square)](https://travis-ci.com/libp2p/pull-mplex)
 [![Dependency Status](https://david-dm.org/libp2p/pull-mplex.svg?style=flat-square)](https://david-dm.org/libp2p/pull-mplex)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
-[![Travis CI](https://flat.badgen.net/travis/libp2p/pull-mplex)](https://travis-ci.com/libp2p/pull-mplex)
 
 > pull-streams based multiplexer implementing the [mplex spec](https://github.com/libp2p/specs/blob/48b3377/mplex/README.md)
 

--- a/package.json
+++ b/package.json
@@ -33,22 +33,22 @@
     "release-major": "aegir release --type major -t node -t browser"
   },
   "devDependencies": {
-    "aegir": "^18.1.0",
+    "aegir": "^18.2.2",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "chunky": "0.0.0",
     "dirty-chai": "^2.0.1",
     "interface-stream-muxer": "~0.6.0",
-    "libp2p-mplex": "~0.8.4",
+    "libp2p-mplex": "~0.8.5",
     "pull-abortable": "^4.1.1",
     "pull-defer": "~0.2.3",
     "pull-generate": "^2.2.0",
-    "pull-length-prefixed": "^1.3.1",
+    "pull-length-prefixed": "^1.3.2",
     "pull-stream-to-stream": "^1.3.4",
     "pump": "^3.0.0"
   },
   "dependencies": {
-    "async": "^2.6.1",
+    "async": "^2.6.2",
     "buffer-reuse-pool": "^1.0.0",
     "debug": "^4.1.1",
     "interface-connection": "~0.3.3",


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated.