### PR TITLE
fix: ensure the channel name is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "pull-generate": "^2.2.0",
     "pull-length-prefixed": "^1.3.2",
     "pull-stream-to-stream": "^1.3.4",
-    "pump": "^3.0.0"
+    "pump": "^3.0.0",
+    "sinon": "^7.3.2"
   },
   "dependencies": {
     "async": "^2.6.2",

--- a/src/mplex.js
+++ b/src/mplex.js
@@ -112,6 +112,7 @@ class Mplex extends EE {
    * @param {Buffer|string} data Logged with the metadata. Must be `.toString` capable. Default: `''`
    */
   _log (name, data) {
+    if (!log.enabled) return
     log({
       op: name,
       initiator: this._initiator,
@@ -189,7 +190,7 @@ class Mplex extends EE {
   createStream (name) {
     if (typeof name === 'number') { name = name.toString() }
     const chan = this._newStream(null, true, false, name, this._outChannels)
-    if (!this._lazy) { chan.openChan(name) }
+    if (!this._lazy) { chan.openChan(chan.name) }
     return chan
   }
 
@@ -229,7 +230,7 @@ class Mplex extends EE {
     }
     const chan = new Channel({
       id,
-      name,
+      name: String(name || id),
       plex: this,
       initiator,
       open: open || false

--- a/test/plex.spec.js
+++ b/test/plex.spec.js
@@ -7,6 +7,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(require('chai-checkmark'))
 chai.use(dirtyChai)
+const sinon = require('sinon')
 
 const pull = require('pull-stream')
 const pair = require('pull-pair/duplex')
@@ -14,10 +15,15 @@ const abortable = require('pull-abortable')
 
 const coder = require('../src/coder')
 const Plex = require('../src/mplex')
+const { Types } = require('../src/consts')
 
 const noop = () => {}
 
 describe('plex', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
   it(`destroy should close both ends`, (done) => {
     const p = pair()
 
@@ -43,6 +49,19 @@ describe('plex', () => {
       expect().mark()
     })
     plex1.destroy()
+  })
+
+  it('create stream should create channel with name', () => {
+    const plex1 = new Plex()
+    sinon.spy(plex1, 'push')
+    plex1.createStream()
+
+    expect(plex1.push.callCount).to.eql(1)
+    expect(plex1.push.getCall(0).args[0]).to.eql([
+      0, Types.NEW, '0'
+    ])
+
+    plex1.close()
   })
 
   it(`closing stream should close all channels`, (done) => {


### PR DESCRIPTION
The channel name was not properly being set for channels we created, so the name was not being passed to the peer.